### PR TITLE
test: `.clear` method

### DIFF
--- a/src/CachedFactory.test.ts
+++ b/src/CachedFactory.test.ts
@@ -49,16 +49,18 @@ describe("CachedFactory", () => {
 	});
 
 	it("clears the cache when .clear is executed", () => {
-		const getter = vi.fn().mockImplementation((key: string) => Symbol(key));
+		const getter = vi
+			.fn()
+			.mockReturnValueOnce("first")
+			.mockReturnValue("second");
+
 		const cachedFactory = new CachedFactory(getter);
 
-		const initialValue = cachedFactory.get("key");
-		expect(cachedFactory.get("key")).toEqual(initialValue);
+		const first = cachedFactory.get("key");
 
 		cachedFactory.clear();
 
-		const nextValue = cachedFactory.get("key");
-		expect(cachedFactory.get("key")).toEqual(nextValue);
-		expect(cachedFactory.get("key")).not.toEqual(initialValue);
+		const second = cachedFactory.get("key");
+		expect(second).not.toEqual(first);
 	});
 });

--- a/src/CachedFactory.test.ts
+++ b/src/CachedFactory.test.ts
@@ -48,26 +48,11 @@ describe("CachedFactory", () => {
 		expect(getter.mock.calls).toEqual([["key-first"], ["key-second"]]);
 	});
 
-	it("clears the cache when .clear is executed", async () => {
-		const wait = (ms: number) =>
-			new Promise<void>((resolve) => {
-				setTimeout(() => {
-					resolve();
-				}, ms);
-			});
-
-		const getter = vi.fn().mockImplementation((key: string) => {
-			const fn = () => {
-				return `${key}-${Date.now()}`;
-			};
-
-			return fn();
-		});
+	it("clears the cache when .clear is executed", () => {
+		const getter = vi.fn().mockImplementation((key: string) => Symbol(key));
 		const cachedFactory = new CachedFactory(getter);
 
 		const initialValue = cachedFactory.get("key");
-		expect(cachedFactory.get("key")).toEqual(initialValue);
-		await wait(1);
 		expect(cachedFactory.get("key")).toEqual(initialValue);
 
 		cachedFactory.clear();

--- a/src/CachedFactory.test.ts
+++ b/src/CachedFactory.test.ts
@@ -47,4 +47,33 @@ describe("CachedFactory", () => {
 
 		expect(getter.mock.calls).toEqual([["key-first"], ["key-second"]]);
 	});
+
+	it("clears the cache when .clear is executed", async () => {
+		const wait = (ms: number) =>
+			new Promise<void>((resolve) => {
+				setTimeout(() => {
+					resolve();
+				}, ms);
+			});
+
+		const getter = vi.fn().mockImplementation((key: string) => {
+			const fn = () => {
+				return `${key}-${Date.now()}`;
+			};
+
+			return fn();
+		});
+		const cachedFactory = new CachedFactory(getter);
+
+		const initialValue = cachedFactory.get("key");
+		expect(cachedFactory.get("key")).toEqual(initialValue);
+		await wait(1);
+		expect(cachedFactory.get("key")).toEqual(initialValue);
+
+		cachedFactory.clear();
+
+		const nextValue = cachedFactory.get("key");
+		expect(cachedFactory.get("key")).toEqual(nextValue);
+		expect(cachedFactory.get("key")).not.toEqual(initialValue);
+	});
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to cached-factory! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/cached-factory/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/cached-factory/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Since `.get` returns the same value for a key that was previously cached, how can we
prove that the cache was truly cleared when we pass in the same key which will return
the same value as before? Since there is no difference between the new value and the
old value, we cannot sufficiently prove that the cache was cleared and a different value
exists for the same key.

My initial idea was to use a closure as the return value of the factory as seen in [2ca7b45f](https://github.com/JoshuaKGoldberg/cached-factory/commit/2ca7b45f0f11a183678b6ff4251def651bd4e71f)
to generate new values with `Date.now`; but there's a better way with `Symbol`

According to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)

> Every Symbol() call is guaranteed to return a unique Symbol.

Since new `Symbol` values will be generated even for the same `key`, we can prove that the
cache was cleared by testing that the new value returned from the `.get` call is different from
the former value from the `.get` call after the cache has been cleared with `.clear`
![image](https://github.com/JoshuaKGoldberg/cached-factory/assets/37955249/a32029cc-85db-421d-805b-00aad37e14c1)

