### PR TITLE
feat: add `.entries()`

### DIFF
--- a/src/CachedFactory.test.ts
+++ b/src/CachedFactory.test.ts
@@ -63,4 +63,17 @@ describe("CachedFactory", () => {
 		const second = cachedFactory.get("key");
 		expect(second).toEqual(secondValue);
 	});
+
+	it("returns entries when .entries() is called", () => {
+		const value = "value";
+		const getter = vi.fn().mockReturnValueOnce(value).mockReturnValue("second");
+		const cachedFactory = new CachedFactory(getter);
+
+		const key = "key";
+		cachedFactory.get(key);
+
+		const actual = cachedFactory.entries();
+
+		expect(Array.from(actual)).toEqual([[key, value]]);
+	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ export class CachedFactory<Key, Value> {
 		this.#cache.clear();
 	}
 
+	entries() {
+		return this.#cache.entries();
+	}
+
 	get(key: Key) {
 		const existing = this.#cache.get(key);
 		if (existing) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #17
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/cached-factory/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/cached-factory/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `.entries()` method that directly returns the cached Map's entries.

💖 